### PR TITLE
:mailbox_with_no_mail: Set cookie to root of domain for single disclaimer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,6 @@ bld/
 
 #node things
 npm-debug.log
+node_modules
 
 .settings

--- a/_source/javascripts/alpha-disclaimer.js
+++ b/_source/javascripts/alpha-disclaimer.js
@@ -6,7 +6,7 @@
         $('#disclaimerModal').modal('show');
     });
     $('#disclaimerModal').on('hidden.bs.modal', function () {
-        $.cookie("acceptedDisclaimer", 1);
+        $.cookie("acceptedDisclaimer", 1, { path: '/' });
     });
     $('.hide-disclaimer').click(function () {
         $('.disclaimer.alert').hide();

--- a/www/javascripts/alpha-disclaimer.js
+++ b/www/javascripts/alpha-disclaimer.js
@@ -6,7 +6,7 @@
         $('#disclaimerModal').modal('show');
     });
     $('#disclaimerModal').on('hidden.bs.modal', function () {
-        $.cookie("acceptedDisclaimer", 1);
+        $.cookie("acceptedDisclaimer", 1, { path: '/' });
     });
     $('.hide-disclaimer').click(function () {
         $('.disclaimer.alert').hide();


### PR DESCRIPTION
The disclaimer message should only appear once per visit to the alpha.nhs.uk domain. Setting the path to the root of the domain should achieve this.
And added `\node_modules` to be ignored (an artifact directory generated when building).