### PR TITLE
Updated tasks styles to remove padding on mobile

### DIFF
--- a/_source/_components/feature-homelinks.ejs
+++ b/_source/_components/feature-homelinks.ejs
@@ -1,5 +1,5 @@
 <style>body { background: #f4f4f4; }</style>
-<div style="font-size:14px; padding: 2em 0 2px;">
+<div class="task__container">
 <div class="container">
     <div class="content-links row">
         <div class="col-sm-4 col-md-3">

--- a/_source/stylesheets/tasks.less
+++ b/_source/stylesheets/tasks.less
@@ -27,6 +27,12 @@
     width:95%;
 }
 
+.task__container{
+    font-size:14px; 
+    padding: 2em 0 2px;
+}
+
+
 .task.stethoscope {
     background-image: url('../images/stethoscope-small.png');
 }
@@ -196,5 +202,10 @@
     .links-container .task {
         border-right: 0;
         border-left: 0;
+    }
+
+    
+    .task__container{
+    padding: 0 0 0;
     }
 }


### PR DESCRIPTION
To remove unnecessary padding from sub 480px viewports above task tiles